### PR TITLE
use logrotate only for catalina.out, others are rotated by slf4j

### DIFF
--- a/src/deb/etc/logrotate.d/odn-midpoint
+++ b/src/deb/etc/logrotate.d/odn-midpoint
@@ -1,4 +1,4 @@
-/var/log/odn-midpoint/* {
+/var/log/odn-midpoint/catalina.out {
   copytruncate
   weekly
   rotate 52


### PR DESCRIPTION
see https://github.com/OpenDataNode/open-data-node/issues/278